### PR TITLE
Update pip3 before installing docker-compose

### DIFF
--- a/ansible/plugin-docker/plugin-docker-compose.yml
+++ b/ansible/plugin-docker/plugin-docker-compose.yml
@@ -14,6 +14,9 @@
     - name: Install docker
       apt:
         name: docker.io
+        
+    - name: Update pip3 version
+      shell: pip3 install --upgrade pip
 
     - name: Install docker-compose (1/2)
       get_url:


### PR DESCRIPTION
One of docker-compose's prerequisite packages requires a newer version of pip3 to be installed.